### PR TITLE
Remove redundant --port option to nats-server CLI

### DIFF
--- a/src/main/java/nats/io/NatsServerRunner.java
+++ b/src/main/java/nats/io/NatsServerRunner.java
@@ -261,8 +261,6 @@ public class NatsServerRunner implements AutoCloseable {
 
                     if (portMatcher.find()) {
                         line = line.replace(portMatcher.group(1), String.valueOf(_port));
-                        cmd.add("--port");
-                        cmd.add(String.valueOf(_port));
                     }
 
                     writer.write(line);


### PR DESCRIPTION
...since it interferes with websocket testing.

Sorry for the delay on the PR, I finally realized that when I tried to test locally, the version was not matching and so gradle was pulling the older version of code and not my test version.